### PR TITLE
sha256.h: improved portability

### DIFF
--- a/sha256.h
+++ b/sha256.h
@@ -11,18 +11,19 @@
 
 /*************************** HEADER FILES ***************************/
 #include <stddef.h>
+#include <stdint.h>
 
 /****************************** MACROS ******************************/
 #define SHA256_BLOCK_SIZE 32            // SHA256 outputs a 32 byte digest
 
 /**************************** DATA TYPES ****************************/
-typedef unsigned char BYTE;             // 8-bit byte
-typedef unsigned int  WORD;             // 32-bit word, change to "long" for 16-bit machines
+typedef uint8_t   BYTE;                 // 8-bit byte
+typedef uint32_t  WORD;                 // 32-bit word, change to "long" for 16-bit machines
 
 typedef struct {
 	BYTE data[64];
 	WORD datalen;
-	unsigned long long bitlen;
+	uint64_t bitlen;
 	WORD state[8];
 } SHA256_CTX;
 


### PR DESCRIPTION
- changed BYTE from `unsigned char` to `uint8_t`
- changed WORD from `unsigned int` to `uint32_t`
- changed `unsigned long long` to `uint64_t`

Signed-off-by: Benjamin Stürz <benni@stuerz.xyz>