### PR TITLE
Testing options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+oceantoo
+*.o


### PR DESCRIPTION
added -1, -2, and -c options to allow testing by forcing the LFSRs to
a specific state

example, set the captain LFSR to high=0x1,low=0x0:
./oceantoo -1 0x1 -2 0 -c tests/example.gray /dev/stdout | xxd

example, set the 3 LFSRs to all have high=0x1,low=0x0:
./oceantoo -1 0x1 -2 0 tests/example.gray /dev/stdout | xxd